### PR TITLE
Fixed the deployed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Kindler is a streamlined way for software developers and recruiters to match wit
 
 > The site is hosted on Heroku, so please allow a few moments for the app to spin up.
 
-[Kindler Live Deployment](https://kindler-9621bf2094f8.herokuapp.com//)
+[Kindler Live Deployment](https://kindler-9621bf2094f8.herokuapp.com/)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Kindler is a streamlined way for software developers and recruiters to match wit
 
 > The site is hosted on Heroku, so please allow a few moments for the app to spin up.
 
-[Kindler Live Deployment](https://guarded-castle-49878.herokuapp.com/)
+[Kindler Live Deployment](https://kindler-9621bf2094f8.herokuapp.com//)
 
 <br>
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": "16.x"
+  },
   "scripts": {
     "start": "node server --ignore client",
     "build": "cd client && npm run build",


### PR DESCRIPTION
Webpack doesn't work well with node v18. Thus, downgrade the node to v16. 
Also, the previous heroku account no longer support free deployment.  Changed the source and updated the link in readme. 